### PR TITLE
Fixes heatmap plugin url no accessible

### DIFF
--- a/rootfs/tpls/etc/nginx/nginx.conf
+++ b/rootfs/tpls/etc/nginx/nginx.conf
@@ -99,7 +99,7 @@ http {
         }
 
         ## only allow accessing the following php files
-        location ~ ^/(index|matomo|piwik|js/index|plugins/HeatmapSessionRecording/configs).php {
+        location ~ ^/(index|matomo|piwik|js/index|data-plugins/HeatmapSessionRecording/configs).php {
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             set $path_info $fastcgi_path_info;
             try_files $fastcgi_script_name =404;


### PR DESCRIPTION
This is a ported fix from https://github.com/crazy-max/docker-matomo/pull/160